### PR TITLE
Updated rounding of nanoseconds and current date

### DIFF
--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -305,7 +305,7 @@
             var us = ns / 1000;
             if (us >= 1) {
               this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
-              this.alternateUnit = " ≈ " + addCommas(ns / 1000) + "μs";
+              this.alternateUnit = " &#8776; " + addCommas(ns / 1000) + "&mu;s";
             } else {
               this.nsDisplay = addCommas(ns);
               this.alternateUnit = "";
@@ -325,7 +325,7 @@
             var us = ns / 1000;
             if (us >= 1) {
               this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
-              this.alternateUnit = " ≈ " + addCommas(ns / 1000) + "μs";
+              this.alternateUnit = " &#8776; " + addCommas(ns / 1000) + "&mu;s";
             } else {
               this.nsDisplay = addCommas(ns);
               this.alternateUnit = "";

--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -303,7 +303,14 @@
           this.boxes = ns / 10000;
           this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
           if (displayString != "") {
-             this.alternateUnit = " &#8776; " + addCommas(ns / 1000) + "&mu;s";
+            var us = ns / 1000;
+            if (us >= 1) {
+              this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
+              this.alternateUnit = " ≈ " + addCommas(ns / 1000) + "μs";
+            } else {
+              this.nsDisplay = addCommas(ns);
+              this.alternateUnit = "";
+            }
           } else {
              this.alternateUnit = " = 1ms";
           }
@@ -315,8 +322,14 @@
             this.nsDisplay = addCommas(Math.round(ns / 1000000) * 1000000);
             this.alternateUnit = " &#8776; " + addCommas(ns / 1000000) + "ms";
           } else {
-            this.nsDisplay = addCommas(Math.round(Math.max(ns / 100000,1)) * 100000);
-            this.alternateUnit = "";
+            var us = ns / 1000;
+            if (us >= 1) {
+              this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
+              this.alternateUnit = " ≈ " + addCommas(ns / 1000) + "μs";
+            } else {
+              this.nsDisplay = addCommas(ns);
+              this.alternateUnit = "";
+            }
           }
         }
 

--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -58,7 +58,7 @@
     // TODO: get more accurate doubling rates from Aurojit Panda's
     //       spreadsheet: http://www.eecs.berkeley.edu/~rcs/research/hw_trends.xlsx
 
-    var year = 2012;
+    var year = new Date().getFullYear();
     function shift(year) {
         return year - 1982;
     }

--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -301,7 +301,6 @@
         } else if (boxType == "10us") {
           this.color = green;
           this.boxes = ns / 10000;
-          this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
           if (displayString != "") {
             var us = ns / 1000;
             if (us >= 1) {
@@ -312,7 +311,8 @@
               this.alternateUnit = "";
             }
           } else {
-             this.alternateUnit = " = 1ms";
+            this.nsDisplay = addCommas(Math.round(ns / 1000) * 1000);
+            this.alternateUnit = " = 1ms";
           }
         } else if (boxType == "ms") {
           this.color = red;


### PR DESCRIPTION
I don't know if you are still interested in this project given that the last commit was 3 years ago, but I figured I would make this pull request anyway. If you're wondering how I found this project, someone posted a link to it in a Quora question about Jeff Dean's numbers every programmer should know, and Quora in turn highlighted that answer on their social media.

The first change I have made is that in the 10us case, if the time is less than 1us then the result will just be displayed in nanoseconds exactly. This was because from ~2012 onwards there were some rounding effects where it would display results like 1,000ns ~= 0.7us. I have also done the same for the ms case, where if the time is smaller than 1ms it will switch to showing the result in us and then ns when the time drops below 1us.

The second change is that I have modified the default year so that instead of being hardcoded, it switches to the current year.

Both of these changes have been tested in the latest versions of Firefox and Chrome on Windows 8.