### PR TITLE
access library files using jsdelivr instead of google

### DIFF
--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -45,10 +45,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="//d3js.org/d3.v3.min.js"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/d3@3.5.17/d3.min.js"></script>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/jquery.ui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="//cdn.jsdelivr.net/npm/jquery@3.1.0/dist/jquery.min.js"></script>
+    <script src="//cdn.jsdelivr.net/jquery.ui/1.11.4/jquery-ui.min.js"></script>
 
     <script>
     // Notes:


### PR DESCRIPTION
A simple PR mentioned at #9 

Jsdelivr has good speed in china and global. If there is better CDN provider, please let me know 😄 