### PR TITLE
Localize slider effect to a single row

### DIFF
--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -427,8 +427,9 @@
         </div>
       </div>
       <div id="slider">
-      <div class="row-fluid">
-        <div class="span12"></div>
+        <div class="row-fluid">
+          <div class="span12"></div>
+        </div>
       </div>
       <div class="row-fluid">
         <div class="span3">


### PR DESCRIPTION
In the live app, the slider effect is present on all the content. Absentminded clicking will snap the slider to the value directly above the click. Also, text selection doesn't work.

This PR cuts off the slider `div` before the latency figures begin. Since there's an unclosed `div` at the end of the body, I assume that this was the original intent.