### PR TITLE
Performance improvements

### DIFF
--- a/interactive_latency.html
+++ b/interactive_latency.html
@@ -216,17 +216,14 @@
     }
 
     // Display functions:
-    function drawBoxes(n, div, color) {
+    function createBoxes(n, color) {
         var cw = 100;
-        var ch = (n / 10) * 10;
-        if ((n % 10) != 0) {
-          ch += 10;
-        }
-        var rects = d3.select("#" + div).
+        var ch = Math.ceil(n / 10) * 10;
+        var rects = d3.select(document.createDocumentFragment()).
           append("svg:svg").
           attr("width", cw).
           attr("height", ch).
-          attr("style", color);
+          attr("style", "display: block; " + color);
 
         var length = 10;
         var whitespace = 2;
@@ -246,10 +243,12 @@
 
                 n -= 1;
                 if (n <= 0) {
-                   return;
+                   return rects;
                 }
             }
         }
+
+        return rects;
     }
 
     function singleBox(color) {
@@ -344,8 +343,10 @@
                               this.alternateUnit + " " + optionalSuffix);
         this.div = div;
         this.fillDiv = function() {
-          document.getElementById(this.div).innerHTML = "";
-          drawBoxes(this.boxes, this.div, this.color);
+          var boxes = createBoxes(this.boxes, this.color);
+          var div = document.getElementById(this.div);
+          div.innerHTML = "";
+          div.appendChild(boxes.node());
           document.getElementById(this.div + "t").innerHTML = this.displayString;
         }
     }
@@ -405,6 +406,7 @@
       body {
         padding-top: 60px;
         padding-bottom: 40px;
+        overflow-y: scroll;
       }
       .sidebar-nav {
         padding: 9px 0;


### PR DESCRIPTION
In a test on my machine the old version gave me about 5fps when dragging the slider near the left hand side of the range.  After this change it is up to about 10fps.  That's still not great but it is the best I could do with small, targeted changes.

- Instead of appending many svg:rect elements directly into the page, put them
all into a document fragment and then insert the document fragment into the
page.  This makes less work for the browser overall as it doesn't need to worry
about performing layout for each svg:rect added, but instead just once per svg.

- Make svg elements use `display: block`.  Otherwise they are aligned to the
baseline and svg elements that are less tall than a single line will start at a
different y position on the page than svg elements that are taller.

- Fix height calculation for svg elements.  This was attempting to round to the
next highest multiple of 10 pixels but it wasn't working.  This, combined with
the problem described in the point above, means that some svg elements would
creep down the page a pixel at a time as the slider was dragged to the right.

- Always display the vertical scrollbar.  This prevents it from popping in and
out of existence as the slider is moved between 2000 and 2001.  That avoids
the need to resize all the columns and reflow the entire page.