### PR TITLE
Mending a minor inconvenience.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Published at <https://people.eecs.berkeley.edu/~rcs/research/interactive_latency
 
 The terminal version is available at cheat.sh/latencies
 ```
-$ curl cheat.sh/latencies
+curl cheat.sh/latencies
 ```
 
 Happy to push out a new version if you get a pull request accepted!


### PR DESCRIPTION
Removing the '$' in the documented curl command.
When using the copy icon on the right, the dollar sign also gets pasted into the terminal.